### PR TITLE
Interactive compiler refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ gaps.
 - `print 1 + 1;` causes a RuntimeFault (Synchronize)
 - Editing and running
   - Working Editor class
+  - An InteractiveCommand visitor pattern? I'm doing an if instanceof block now and
+    it's mid
   - Commands
     - new
       - clear the program

--- a/README.md
+++ b/README.md
@@ -30,15 +30,7 @@ gaps.
 
 ### Prioritized Backlog
 
-- Refactor compiler to support mixed interpreted/compiled commands
-  - [X] Refactor Compiler into LineCompiler
-  - [X] Flesh out CommandCompiler and compileCommands interface
-  - [X] Implement a merge function for syntax warnings and issues
-  - [X] Merge warnings in CommandCompiler and compileCommands
-  - [X] Call compileCommands from Commander
-  - [X] Merge warnings/errors in Commander
-  - [X] Tests for mergeParseErrors
-  - [ ] Tests for compileCommands
+- Tests for interactive compiler
 - `print 1 + 1;` causes a RuntimeFault (Synchronize)
 - Editing and running
   - Working Editor class

--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ gaps.
   - [X] Flesh out CommandCompiler and compileCommands interface
   - [X] Implement a merge function for syntax warnings and issues
   - [X] Merge warnings in CommandCompiler and compileCommands
-  - [ ] Call compileCommands from Commander
-  - [ ] Merge warnings/errors in Commander
+  - [X] Call compileCommands from Commander
+  - [X] Merge warnings/errors in Commander
   - [ ] Tests for mergeParseErrors
   - [ ] Tests for compileCommands
+- `print 1 + 1;` causes a RuntimeFault (Synchronize)
 - Editing and running
   - Working Editor class
   - Commands

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ gaps.
   - [X] Merge warnings in CommandCompiler and compileCommands
   - [X] Call compileCommands from Commander
   - [X] Merge warnings/errors in Commander
-  - [ ] Tests for mergeParseErrors
+  - [X] Tests for mergeParseErrors
   - [ ] Tests for compileCommands
 - `print 1 + 1;` causes a RuntimeFault (Synchronize)
 - Editing and running

--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ gaps.
 ### Prioritized Backlog
 
 - Refactor compiler to support mixed interpreted/compiled commands
-  - See [this draft PR here](https://github.com/jfhbrook/matanuska/pull/9/files)
-  - BONUS: Merge errors from parser and compiler
+  - [X] Refactor Compiler into LineCompiler
+  - [X] Flesh out CommandCompiler and compileCommands interface
+  - [ ] Implement a merge function for syntax warnings and issues
+  - [ ] Merge warnings in CommandCompiler and compileCommands
+  - [ ] Call compileCommands from Commander
+  - [ ] Merge warnings/errors in Commander
 - Editing and running
   - Working Editor class
   - Commands

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ gaps.
 - Refactor compiler to support mixed interpreted/compiled commands
   - [X] Refactor Compiler into LineCompiler
   - [X] Flesh out CommandCompiler and compileCommands interface
-  - [ ] Implement a merge function for syntax warnings and issues
-  - [ ] Merge warnings in CommandCompiler and compileCommands
+  - [X] Implement a merge function for syntax warnings and issues
+  - [X] Merge warnings in CommandCompiler and compileCommands
   - [ ] Call compileCommands from Commander
   - [ ] Merge warnings/errors in Commander
+  - [ ] Tests for mergeParseErrors
+  - [ ] Tests for compileCommands
 - Editing and running
   - Working Editor class
   - Commands

--- a/commander.ts
+++ b/commander.ts
@@ -166,7 +166,6 @@ export class Commander {
       try {
         const [commands, warning] = compileCommands(cmds.commands, {
           filename: '<input>',
-          // TODO: Refactor this
           cmdNo: this.cmdNo,
           cmdSource: this.cmdSource,
         });
@@ -225,7 +224,7 @@ export class Commander {
       return args[0];
     }
 
-    throw new Error('unreachable.');
+    throw new Error('Unreachable.');
   }
 
   //
@@ -233,7 +232,6 @@ export class Commander {
   //
   private runCommand([cmd, chunks]: CompiledCmd): Value | null {
     return tracer.spanSync('runCommand', () => {
-      console.log(cmd, chunks);
       try {
         const args = chunks.map((c) => this.runtime.interpret(c));
 

--- a/commander.ts
+++ b/commander.ts
@@ -195,7 +195,8 @@ export class Commander implements CmdVisitor<Value | null> {
     return tracer.span('evalProgram', async () => {
       let chunk: Chunk;
       try {
-        chunk = compile(program, { filename });
+        const result = compile(program, { filename });
+        chunk = result[0];
       } catch (err) {
         if (err instanceof Exception) {
           this.host.writeException(err);
@@ -238,11 +239,12 @@ export class Commander implements CmdVisitor<Value | null> {
     return tracer.spanSync('runCommand', () => {
       let chunk: Chunk;
       try {
-        chunk = compile(cmd, {
+        const result = compile(cmd, {
           filename: '<input>',
           cmdNo: this.cmdNo,
           cmdSource: this.cmdSource,
         });
+        chunk = result[0];
       } catch (err) {
         if (err instanceof Exception) {
           this.host.writeException(err);

--- a/commander.ts
+++ b/commander.ts
@@ -2,7 +2,7 @@ import * as readline from 'node:readline/promises';
 
 import { getTracer } from './debug';
 import { Chunk } from './bytecode/chunk';
-import { compile } from './compiler';
+import { compileCommand, compileProgram } from './compiler';
 import { Config } from './config';
 import { Exception } from './exceptions';
 import { inspector } from './format';
@@ -195,7 +195,7 @@ export class Commander implements CmdVisitor<Value | null> {
     return tracer.span('evalProgram', async () => {
       let chunk: Chunk;
       try {
-        const result = compile(program, { filename });
+        const result = compileProgram(program, { filename });
         chunk = result[0];
       } catch (err) {
         if (err instanceof Exception) {
@@ -239,7 +239,7 @@ export class Commander implements CmdVisitor<Value | null> {
     return tracer.spanSync('runCommand', () => {
       let chunk: Chunk;
       try {
-        const result = compile(cmd, {
+        const result = compileCommand(cmd, {
           filename: '<input>',
           cmdNo: this.cmdNo,
           cmdSource: this.cmdSource,

--- a/compiler.ts
+++ b/compiler.ts
@@ -524,7 +524,7 @@ export function compileCommands(
   const results = cmds.map((cmd) => cmd.accept(compiler));
   const commands = results
     .map(([cmd, _]) => cmd)
-    .filter((c) => !(c instanceof Rem));
+    .filter(([c, _]) => !(c instanceof Rem));
   const warnings = results.reduce(
     (acc, [_, warns]) => (warns ? acc.concat(warns) : acc),
     [],

--- a/compiler.ts
+++ b/compiler.ts
@@ -47,7 +47,7 @@ export type CompilerOptions = {
   cmdSource?: string;
 };
 
-export type CompilerResult = [Chunk, ParseWarning | null];
+export type CompileResult = [Chunk, ParseWarning | null];
 
 export class Compiler implements CmdVisitor<void>, ExprVisitor<void> {
   private ast: Cmd | Program | null;
@@ -102,7 +102,7 @@ export class Compiler implements CmdVisitor<void>, ExprVisitor<void> {
    * @param filename The source filename.
    */
   @runtimeMethod
-  compile(): CompilerResult {
+  compile(): CompileResult {
     return tracer.spanSync('compile', () => {
       let cmd: Cmd | null = this.advance();
       while (cmd) {
@@ -433,8 +433,8 @@ export class Compiler implements CmdVisitor<void>, ExprVisitor<void> {
   }
 }
 
-// Note, the CompilerResult[] will include unmerged warnings...
-type CompiledCmd = [Cmd | null, CompilerResult[]];
+// Note, the CompileResult[] will include unmerged warnings...
+type CompiledCmd = [Cmd | null, CompileResult[]];
 
 export class CommandCompiler implements CmdVisitor<CompiledCmd> {
   constructor(private options: CompilerOptions) {}
@@ -474,7 +474,7 @@ export class CommandCompiler implements CmdVisitor<CompiledCmd> {
 export function compile(
   ast: Program | Cmd,
   options: CompilerOptions = {},
-): CompilerResult {
+): CompileResult {
   const compiler = new Compiler(ast, options);
   return compiler.compile();
 }
@@ -482,7 +482,7 @@ export function compile(
 export function compileProgram(
   program: Program,
   options: CompilerOptions = {},
-): CompilerResult {
+): CompileResult {
   return compile(program, options);
 }
 

--- a/compiler.ts
+++ b/compiler.ts
@@ -466,7 +466,7 @@ export function compileProgram(
   return compiler.compile();
 }
 
-type CompiledCmd = [Cmd | null, Chunk[]];
+export type CompiledCmd = [Cmd | null, Chunk[]];
 
 //
 // Compiler for both interactive and runtime commands. For more information,
@@ -498,7 +498,7 @@ export class CommandCompiler implements CmdVisitor<CompileResult<CompiledCmd>> {
   }
 
   visitExpressionCmd(expr: Expression): CompileResult<CompiledCmd> {
-    return this.compiled(expr);
+    return this.interactive(expr, [expr.expression]);
   }
 
   visitRemCmd(rem: Rem): CompileResult<CompiledCmd> {

--- a/exceptions.ts
+++ b/exceptions.ts
@@ -548,11 +548,11 @@ function merge<T extends SourceLocation>(xs: T[], ys: T[]): T[] {
     if (j >= ys.length) {
       return merged.concat(xs.slice(i));
     }
-    if (xs[0].row < ys[0].row) {
+    if (xs[i].row < ys[j].row) {
       merged.push(xs[i++]);
-    } else if (xs[0].row > ys[0].row) {
+    } else if (xs[i].row > ys[j].row) {
       merged.push(ys[j++]);
-    } else if (xs[0].offsetStart <= ys[0].offsetStart) {
+    } else if (xs[i].offsetStart <= ys[j].offsetStart) {
       merged.push(xs[i++]);
     } else {
       merged.push(ys[j++]);

--- a/tap-snapshots/test/exceptions.ts.test.cjs
+++ b/tap-snapshots/test/exceptions.ts.test.cjs
@@ -1,0 +1,287 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/exceptions.ts > TAP > mergeParseErrors > merge a few nulls 1`] = `
+null
+`
+
+exports[`test/exceptions.ts > TAP > mergeParseErrors > merge a warning and an error 1`] = `
+Exception {
+  "errors": Array [
+    SyntaxWarning: identifier has no sigil {
+      "filename": "/home/josh/script.bas",
+      "isLine": true,
+      "lineNo": 100,
+      "message": "identifier has no sigil",
+      "offsetEnd": 18,
+      "offsetStart": 17,
+      "row": 0,
+      "source": "100 print someFn(ident)",
+      "traceback": null,
+    },
+    SyntaxError: expected ) {
+      "filename": "/home/josh/script.bas",
+      "isLine": false,
+      "lineNo": 300,
+      "message": "expected )",
+      "offsetEnd": 23,
+      "offsetStart": 22,
+      "row": 2,
+      "source": "300 print someFn(ident",
+      "traceback": null,
+    },
+    SyntaxWarning: identifier has no sigil {
+      "filename": "/home/josh/script.bas",
+      "isLine": true,
+      "lineNo": 500,
+      "message": "identifier has no sigil",
+      "offsetEnd": 18,
+      "offsetStart": 17,
+      "row": 4,
+      "source": "500 print someFn(ident)",
+      "traceback": null,
+    },
+    SyntaxError: expected ) {
+      "filename": "/home/josh/script.bas",
+      "isLine": false,
+      "lineNo": 700,
+      "message": "expected )",
+      "offsetEnd": 23,
+      "offsetStart": 22,
+      "row": 6,
+      "source": "700 print someFn(ident",
+      "traceback": null,
+    },
+  ],
+  "exitCode": 70,
+  "message": "",
+  "traceback": null,
+}
+`
+
+exports[`test/exceptions.ts > TAP > mergeParseErrors > merge a warning and null 1`] = `
+ParseWarning {
+  "message": "",
+  "traceback": null,
+  "warnings": Array [
+    SyntaxWarning: identifier has no sigil {
+      "filename": "/home/josh/script.bas",
+      "isLine": true,
+      "lineNo": 100,
+      "message": "identifier has no sigil",
+      "offsetEnd": 18,
+      "offsetStart": 17,
+      "row": 0,
+      "source": "100 print someFn(ident)",
+      "traceback": null,
+    },
+    SyntaxWarning: identifier has no sigil {
+      "filename": "/home/josh/script.bas",
+      "isLine": true,
+      "lineNo": 500,
+      "message": "identifier has no sigil",
+      "offsetEnd": 18,
+      "offsetStart": 17,
+      "row": 4,
+      "source": "500 print someFn(ident)",
+      "traceback": null,
+    },
+  ],
+}
+`
+
+exports[`test/exceptions.ts > TAP > mergeParseErrors > merge a warning, an error and null 1`] = `
+Exception {
+  "errors": Array [
+    SyntaxWarning: identifier has no sigil {
+      "filename": "/home/josh/script.bas",
+      "isLine": true,
+      "lineNo": 200,
+      "message": "identifier has no sigil",
+      "offsetEnd": 18,
+      "offsetStart": 17,
+      "row": 1,
+      "source": "200 print someFn(ident)",
+      "traceback": null,
+    },
+    SyntaxError: expected ) {
+      "filename": "/home/josh/script.bas",
+      "isLine": false,
+      "lineNo": 300,
+      "message": "expected )",
+      "offsetEnd": 23,
+      "offsetStart": 22,
+      "row": 2,
+      "source": "300 print someFn(ident",
+      "traceback": null,
+    },
+    SyntaxWarning: identifier has no sigil {
+      "filename": "/home/josh/script.bas",
+      "isLine": true,
+      "lineNo": 600,
+      "message": "identifier has no sigil",
+      "offsetEnd": 18,
+      "offsetStart": 17,
+      "row": 5,
+      "source": "600 print someFn(ident)",
+      "traceback": null,
+    },
+    SyntaxError: expected ) {
+      "filename": "/home/josh/script.bas",
+      "isLine": false,
+      "lineNo": 700,
+      "message": "expected )",
+      "offsetEnd": 23,
+      "offsetStart": 22,
+      "row": 6,
+      "source": "700 print someFn(ident",
+      "traceback": null,
+    },
+  ],
+  "exitCode": 70,
+  "message": "",
+  "traceback": null,
+}
+`
+
+exports[`test/exceptions.ts > TAP > mergeParseErrors > merge an error and null 1`] = `
+ParseWarning {
+  "message": "",
+  "traceback": null,
+  "warnings": Array [
+    SyntaxWarning: identifier has no sigil {
+      "filename": "/home/josh/script.bas",
+      "isLine": true,
+      "lineNo": 100,
+      "message": "identifier has no sigil",
+      "offsetEnd": 18,
+      "offsetStart": 17,
+      "row": 0,
+      "source": "100 print someFn(ident)",
+      "traceback": null,
+    },
+    SyntaxWarning: identifier has no sigil {
+      "filename": "/home/josh/script.bas",
+      "isLine": true,
+      "lineNo": 500,
+      "message": "identifier has no sigil",
+      "offsetEnd": 18,
+      "offsetStart": 17,
+      "row": 4,
+      "source": "500 print someFn(ident)",
+      "traceback": null,
+    },
+  ],
+}
+`
+
+exports[`test/exceptions.ts > TAP > mergeParseErrors > merge two errors 1`] = `
+Exception {
+  "errors": Array [
+    SyntaxError: expected ) {
+      "filename": "/home/josh/script.bas",
+      "isLine": false,
+      "lineNo": 300,
+      "message": "expected )",
+      "offsetEnd": 23,
+      "offsetStart": 22,
+      "row": 2,
+      "source": "300 print someFn(ident",
+      "traceback": null,
+    },
+    SyntaxError: expected ) {
+      "filename": "/home/josh/script.bas",
+      "isLine": false,
+      "lineNo": 400,
+      "message": "expected )",
+      "offsetEnd": 23,
+      "offsetStart": 22,
+      "row": 3,
+      "source": "400 print someFn(ident",
+      "traceback": null,
+    },
+    SyntaxError: expected ) {
+      "filename": "/home/josh/script.bas",
+      "isLine": false,
+      "lineNo": 700,
+      "message": "expected )",
+      "offsetEnd": 23,
+      "offsetStart": 22,
+      "row": 6,
+      "source": "700 print someFn(ident",
+      "traceback": null,
+    },
+    SyntaxError: expected ) {
+      "filename": "/home/josh/script.bas",
+      "isLine": false,
+      "lineNo": 800,
+      "message": "expected )",
+      "offsetEnd": 23,
+      "offsetStart": 22,
+      "row": 7,
+      "source": "800 print someFn(ident",
+      "traceback": null,
+    },
+  ],
+  "exitCode": 70,
+  "message": "",
+  "traceback": null,
+}
+`
+
+exports[`test/exceptions.ts > TAP > mergeParseErrors > merge two warnings 1`] = `
+ParseWarning {
+  "message": "",
+  "traceback": null,
+  "warnings": Array [
+    SyntaxWarning: identifier has no sigil {
+      "filename": "/home/josh/script.bas",
+      "isLine": true,
+      "lineNo": 100,
+      "message": "identifier has no sigil",
+      "offsetEnd": 18,
+      "offsetStart": 17,
+      "row": 0,
+      "source": "100 print someFn(ident)",
+      "traceback": null,
+    },
+    SyntaxWarning: identifier has no sigil {
+      "filename": "/home/josh/script.bas",
+      "isLine": true,
+      "lineNo": 200,
+      "message": "identifier has no sigil",
+      "offsetEnd": 18,
+      "offsetStart": 17,
+      "row": 1,
+      "source": "200 print someFn(ident)",
+      "traceback": null,
+    },
+    SyntaxWarning: identifier has no sigil {
+      "filename": "/home/josh/script.bas",
+      "isLine": true,
+      "lineNo": 500,
+      "message": "identifier has no sigil",
+      "offsetEnd": 18,
+      "offsetStart": 17,
+      "row": 4,
+      "source": "500 print someFn(ident)",
+      "traceback": null,
+    },
+    SyntaxWarning: identifier has no sigil {
+      "filename": "/home/josh/script.bas",
+      "isLine": true,
+      "lineNo": 600,
+      "message": "identifier has no sigil",
+      "offsetEnd": 18,
+      "offsetStart": 17,
+      "row": 5,
+      "source": "600 print someFn(ident)",
+      "traceback": null,
+    },
+  ],
+}
+`

--- a/test/compiler.ts
+++ b/test/compiler.ts
@@ -16,11 +16,27 @@ import {
 import { Program, Line } from '../ast';
 import { Chunk } from '../bytecode/chunk';
 import { OpCode } from '../bytecode/opcodes';
-import { compile } from '../compiler';
+import {
+  compileCommand,
+  compileProgram,
+  CompilerOptions,
+  CompileResult,
+} from '../compiler';
 import { formatter } from '../format';
 import { TokenKind } from '../tokens';
 
 import { chunk } from './helpers/bytecode';
+
+function compile(
+  ast: Program | Cmd,
+  options: CompilerOptions = {},
+): CompileResult {
+  if (ast instanceof Program) {
+    return compileProgram(ast, options);
+  } else {
+    return compileCommand(ast, options);
+  }
+}
 
 type TestCase = [string, Cmd | Program, Chunk];
 

--- a/test/compiler.ts
+++ b/test/compiler.ts
@@ -281,7 +281,7 @@ COMMANDS = COMMANDS.concat(EXPRESSION_COMMANDS);
 
 function runTest([source, ast, ch]: TestCase): void {
   t.test(source, async (t: Test) => {
-    t.same(compile(ast), ch);
+    t.same(compile(ast)[0], ch);
   });
 }
 

--- a/test/compiler.ts
+++ b/test/compiler.ts
@@ -30,7 +30,7 @@ import { chunk } from './helpers/bytecode';
 function compile(
   ast: Program | Cmd,
   options: CompilerOptions = {},
-): CompileResult {
+): CompileResult<Chunk> {
   if (ast instanceof Program) {
     return compileProgram(ast, options);
   } else {


### PR DESCRIPTION
My intent with this one is to refactor the compiler module so that compiling interactive, non-runtime commands returns the command and compiled sub-expressions.

This is motivated in part by wanting to evaluate expressions in the runtime, instead of insisting on literal arguments. This isn't strictly necessary, but it's a nice-to-have.

It's also motivated by wanting to compile all commands in an interactive row before attempting to run them. This will allow us to fail an entire line if any one piece of it fails to compile, as well as rolling up warnings across all lines.

This starts with the spike on a compiler refactor from #9, but otherwise throws it out. #9's goals were to roll up warnings, but this refactor is effectively a prerequisite for that - I want to focus on the refactor here, and then build warning roll-up on top of it. Needless to say, this supercedes #9.

The big gap left is comprehensive testing for the new interactive compiler interface. But it's relatively small/simple and is pretty well-covered by manual testing. I'd like to improve that coverage, but I'm going to try putting this on a shelf soon and want to button this up.