### PR TITLE
Spike: Hand-Rolled DI

### DIFF
--- a/container.ts
+++ b/container.ts
@@ -14,13 +14,27 @@ export interface Container<H extends Host> {
   executor: Executor;
 }
 
+export interface ExecutorDependencies {
+  config: Config;
+  editor: Editor;
+  host: Host;
+}
+
+export type ExecutorFactory = ({
+  config,
+  editor,
+  host,
+}: ExecutorDependencies) => Executor;
+
 export function container<H extends Host>(
   config: Config,
   host: H,
+  executorFactory: ExecutorFactory = ({ config, editor, host }) =>
+    new Executor(config, editor, host),
 ): Container<H> {
   return tracer.spanSync('container', () => {
     const editor = new Editor(host);
-    const executor = new Executor(config, editor, host);
+    const executor = executorFactory({ config, editor, host });
 
     return {
       config,

--- a/executor.ts
+++ b/executor.ts
@@ -174,6 +174,25 @@ export class Executor {
     // TODO: Close open file handles on this.host
   }
 
+  // TODO: Move these I/O functions into the Host
+  async _readFile(filename: string): Promise<string> {
+    let source: string;
+    try {
+      source = await readFile(filename, 'utf8');
+    } catch (err) {
+      throw FileError.fromError(null, err);
+    }
+    return source;
+  }
+
+  async _writeFile(filename: string, source: string): Promise<void> {
+    try {
+      writeFile(filename, source, 'utf8');
+    } catch (err) {
+      throw FileError.fromError(null, err);
+    }
+  }
+
   /**
    * Load a script into the editor.
    *
@@ -181,13 +200,7 @@ export class Executor {
    * @returns A promise.
    */
   async load(filename: string): Promise<void> {
-    let source: string;
-    try {
-      source = await readFile(filename, 'utf8');
-    } catch (err) {
-      throw FileError.fromError(null, err);
-    }
-
+    const source = await this._readFile(filename);
     let result: ParseResult<Program>;
 
     try {
@@ -216,12 +229,7 @@ export class Executor {
       this.editor.filename = filename;
     }
 
-    // TODO: This writeFile call should be moved into the host
-    try {
-      writeFile(this.editor.filename, this.editor.list() + '\n', 'utf8');
-    } catch (err) {
-      throw FileError.fromError(null, err);
-    }
+    await this._writeFile(this.editor.filename, this.editor.list() + '\n');
   }
 
   /**

--- a/test/commands.ts
+++ b/test/commands.ts
@@ -6,7 +6,9 @@ import { RuntimeFault } from '../faults';
 import { IntLiteral, StringLiteral } from '../ast/expr';
 import { Cmd, Expression, Print, Exit, Rem } from '../ast/cmd';
 
-import { executorTopic as topic } from './helpers/executor';
+import { executorTopic } from './helpers/executor';
+
+const topic = executorTopic();
 
 const INVALID_CMDS: Array<[string, Cmd]> = [
   ['print', new Print(new IntLiteral(1))],

--- a/test/executor.ts
+++ b/test/executor.ts
@@ -1,30 +1,13 @@
 import t from 'tap';
 import { Test } from 'tap';
 
-import { executorTopic as topic } from './helpers/executor';
+import { executorTopic } from './helpers/executor';
 
-t.test('when prompted for a command', async (t: Test) => {
-  t.test('it gets a command', async (t: Test) => {
-    await topic.swear(async ({ executor, host }) => {
-      const prompt = executor.prompt();
-      host.inputStream.write('print "hello world"\n');
+const topic = executorTopic({});
 
-      const command = await prompt;
-      t.matchSnapshot(host.outputStream.output);
-      t.equal(command, 'print "hello world"');
-    });
-  });
-});
-
-t.test('when input is requested', async (t: Test) => {
-  t.test('input is received?', async (t: Test) => {
-    await topic.swear(async ({ executor, host }) => {
-      const question = executor.input('what is your favorite color?');
-      host.inputStream.write('blue\n');
-
-      const input = await question;
-      t.matchSnapshot(host.outputStream.output);
-      t.equal(input, 'blue');
-    });
+t.todo('a meaningful executor test', async (t: Test) => {
+  await topic.swear(async ({ executor, host }) => {
+    t.ok(executor);
+    t.ok(host);
   });
 });

--- a/test/helpers/executor.ts
+++ b/test/helpers/executor.ts
@@ -1,19 +1,102 @@
-import { discuss } from '@jfhbrook/swears';
+import * as assert from 'assert';
 
-import { container } from '../../container';
+import { discuss, Topic } from '@jfhbrook/swears';
+
+import { container, Container } from '../../container';
+import { Config } from '../../config';
+import { Editor } from '../../editor';
+import { Executor } from '../../executor';
+import { Host } from '../../host';
+
 import { CONFIG } from './config';
 import { MockConsoleHost } from './host';
 
-export const executorTopic = discuss(
-  async () => {
-    const host = new MockConsoleHost();
-    const deps = container(CONFIG, host);
+export interface MockExecutorConfig {
+  answers?: string[];
+  inputs?: string[];
+  files?: Record<string, string>;
+}
 
-    await deps.executor.init();
+export class MockExecutor extends Executor {
+  public initialized: boolean = false;
+  public questions: string[];
+  public inputCallCount: number = 0;
+  public promptCallCount: number = 0;
 
-    return deps;
-  },
-  async ({ executor }) => {
-    await executor.close();
-  },
-);
+  constructor(
+    _config: Config,
+    editor: Editor,
+    host: Host,
+    private answers: string[] = [],
+    private inputs: string[] = [],
+    public files: Record<string, string> = {},
+  ) {
+    super(_config, editor, host);
+    this.questions = [];
+  }
+
+  async init(): Promise<void> {
+    this.initialized = true;
+  }
+
+  async close(): Promise<void> {
+    this.initialized = false;
+  }
+
+  async input(question: string): Promise<string> {
+    this.inputCallCount++;
+    this.questions.push(question);
+    const ans = this.answers.shift();
+    assert.ok(ans);
+    return ans;
+  }
+
+  async prompt(): Promise<string> {
+    this.promptCallCount++;
+    const in_ = this.inputs.shift();
+    assert.ok(in_);
+    return in_;
+  }
+
+  async _readFile(filename: string): Promise<string> {
+    const file = this.files[filename];
+    assert.ok(file);
+    return file;
+  }
+
+  async _writeFile(filename: string, source: string): Promise<void> {
+    this.files[filename] = source;
+  }
+}
+
+export interface MockContainer {
+  config: Config;
+  host: MockConsoleHost;
+  editor: Editor;
+  executor: MockExecutor;
+}
+
+export function executorTopic({
+  answers,
+  inputs,
+  files,
+}: MockExecutorConfig = {}): Topic<MockContainer> {
+  return discuss(
+    async () => {
+      const host = new MockConsoleHost();
+      const deps = container(
+        CONFIG,
+        host,
+        ({ config, editor, host }) =>
+          new MockExecutor(config, editor, host, answers, inputs, files),
+      );
+
+      await deps.executor.init();
+
+      return deps as MockContainer;
+    },
+    async ({ executor }) => {
+      await executor.close();
+    },
+  );
+}


### PR DESCRIPTION
Here, I spiked on naively extending my hand-rolled container with ad-hoc extensions for what I need.

It feels ok. Really flexible, and as though I could build up some patterns. I like the executorFactory pattern. The typing isn't super smart - I have to cast to a MockContainer type in my executor - but that doesn't bother me *too* much. I can probably get around it by writing a Container class if I really want to.

In addition to #19, I also looked at typed-inject and tssyringe, but they have the same problem that inversify - but worse, as far as I can tell.

I think I'm gonna spike on converting to nestjs. Nest is a lot more baggage, but I know I like its container and I have good templates to crib from. The choice is probably gonna be between nestjs and this strategy.