### PR TITLE
Inject config

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 
 import { MATBAS_BUILD, MATBAS_VERSION } from './constants';
 import { UsageFault } from './faults';
@@ -78,26 +78,12 @@ function parseLevel(arg: string): Level {
  */
 @Injectable()
 export class Config {
+  public readonly command: string | null;
   public readonly eval: string | null;
-
-  /**
-   * @param command A command to run.
-   * @param eval_ The source of a script to evaluate.
-   * @param script The path to a script to run.
-   * @param logLevel The log level.
-   * @param argv Command line arguments passed to the runtime.
-   * @param env Environment variables.
-   */
-  constructor(
-    public readonly command: string | null,
-    eval_: string | null,
-    public readonly script: string | null,
-    public readonly level: Level,
-    public readonly argv: Argv,
-    public readonly env: Env,
-  ) {
-    this.eval = eval_;
-  }
+  public readonly script: string | null;
+  public readonly level: Level;
+  public readonly argv: Argv;
+  public readonly env: Env;
 
   /**
    * Load configuration from command line arguments and environment variables.
@@ -106,7 +92,7 @@ export class Config {
    *        script name. In practice, this is `process.argv.slice(2)`.
    * @param env Environment variables. In practice, this is `process.env`.
    */
-  static load(argv: Argv, env: Env) {
+  constructor(@Inject('argv') argv: Argv, @Inject('env') env: Env) {
     let command: string | null = null;
     let eval_: string | null = null;
     let script: string | null = null;
@@ -167,7 +153,12 @@ export class Config {
       }
     }
 
-    return new Config(command, eval_, script, level, scriptArgv, env);
+    this.command = command;
+    this.eval = eval_;
+    this.script = script;
+    this.level = level;
+    this.argv = scriptArgv;
+    this.env = env;
   }
 
   /**

--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ import { NestFactory } from '@nestjs/core';
 import { NestLogger } from './debug';
 
 import { App } from './app';
-import { Config, Argv, Env } from './config';
+import { Config } from './config';
 import { ConsoleHost } from './host';
 import { Editor } from './editor';
 import { Executor } from './executor';
@@ -23,16 +23,10 @@ import { Executor } from './executor';
     { provide: 'env', useValue: process.env },
     { provide: 'exitFn', useValue: process.exit },
     {
-      provide: Config,
-      useFactory: (argv: Argv, env: Env) => {
-        return Config.load(argv, env);
-      },
-      inject: ['argv', 'env'],
-    },
-    {
       provide: 'Host',
       useClass: ConsoleHost,
     },
+    Config,
     Editor,
     Executor,
     App,

--- a/test/config.ts
+++ b/test/config.ts
@@ -11,7 +11,7 @@ t.test('help', async (t: Test) => {
     t.test('it shows help text', async (t: Test) => {
       t.plan(2);
       try {
-        Config.load(['-h'], {});
+        new Config(['-h'], {});
       } catch (err) {
         t.type(err, Exit);
         t.match(err.message, /^Usage:/);
@@ -23,7 +23,7 @@ t.test('help', async (t: Test) => {
     t.test('it shows help text', async (t: Test) => {
       t.plan(2);
       try {
-        Config.load(['--help'], {});
+        new Config(['--help'], {});
       } catch (err) {
         t.type(err, Exit);
         t.match(err.message, /^Usage:/);
@@ -37,7 +37,7 @@ t.test('version', async (t: Test) => {
     t.test('it shows the version', async (t: Test) => {
       t.plan(2);
       try {
-        Config.load(['-v'], {});
+        new Config(['-v'], {});
       } catch (err) {
         t.type(err, Exit);
         t.match(err.message, /^v\d+\.\d+\.\d+/);
@@ -49,7 +49,7 @@ t.test('version', async (t: Test) => {
     t.test('it shows the version', async (t: Test) => {
       t.plan(2);
       try {
-        Config.load(['--version'], {});
+        new Config(['--version'], {});
       } catch (err) {
         t.type(err, Exit);
         t.match(err.message, /^v\d+\.\d+\.\d+/);
@@ -61,7 +61,7 @@ t.test('version', async (t: Test) => {
 t.test('command', async (t: Test) => {
   t.test('when the -c option is passed', async (t: Test) => {
     t.test('it sets a command', async (t: Test) => {
-      const config = Config.load(['-c', 'print "hello world"'], {});
+      const config = new Config(['-c', 'print "hello world"'], {});
       t.equal(config.command, 'print "hello world"');
       t.equal(config.eval, null);
       t.equal(config.script, null);
@@ -70,7 +70,7 @@ t.test('command', async (t: Test) => {
 
   t.test('when the --command option is passed', async (t: Test) => {
     t.test('it sets a command', async (t: Test) => {
-      const config = Config.load(['--command', 'print "hello world"'], {});
+      const config = new Config(['--command', 'print "hello world"'], {});
       t.equal(config.command, 'print "hello world"');
       t.equal(config.eval, null);
       t.equal(config.script, null);
@@ -81,7 +81,7 @@ t.test('command', async (t: Test) => {
 t.test('eval', async (t: Test) => {
   t.test('when the -e option is passed', async (t: Test) => {
     t.test('it sets source to eval', async (t: Test) => {
-      const config = Config.load(['-e', '100 print "hello world"'], {});
+      const config = new Config(['-e', '100 print "hello world"'], {});
       t.equal(config.eval, '100 print "hello world"');
       t.equal(config.command, null);
       t.equal(config.script, null);
@@ -90,7 +90,7 @@ t.test('eval', async (t: Test) => {
 
   t.test('when the --eval option is passed', async (t: Test) => {
     t.test('it sets source to eval', async (t: Test) => {
-      const config = Config.load(['--eval', '100 print "hello world"'], {});
+      const config = new Config(['--eval', '100 print "hello world"'], {});
       t.equal(config.eval, '100 print "hello world"');
       t.equal(config.command, null);
       t.equal(config.script, null);
@@ -102,7 +102,7 @@ t.test('script', async (t: Test) => {
   t.test('when a script is passed', async (t: Test) => {
     t.test('and there are no other arguments', async (t: Test) => {
       t.test('it sets the path to a script', async (t: Test) => {
-        const config = Config.load(['./script.bas'], {});
+        const config = new Config(['./script.bas'], {});
         t.equal(config.script, './script.bas');
         t.equal(config.command, null);
         t.equal(config.eval, null);
@@ -111,7 +111,7 @@ t.test('script', async (t: Test) => {
 
     t.test('and there is another argument', async (t: Test) => {
       t.test('it sets the path to a script', async (t: Test) => {
-        const config = Config.load(['./script.bas', 'arg'], {});
+        const config = new Config(['./script.bas', 'arg'], {});
         t.equal(config.script, './script.bas');
         t.equal(config.command, null);
         t.equal(config.eval, null);
@@ -123,7 +123,7 @@ t.test('script', async (t: Test) => {
       t.test(
         'it sets the path to a script and respects the option',
         async (t: Test) => {
-          const config = Config.load(
+          const config = new Config(
             ['-c', 'print "hello world"', './script.bas'],
             {},
           );
@@ -139,7 +139,7 @@ t.test('script', async (t: Test) => {
       t.test('it exits with a usage fault', async (t: Test) => {
         t.plan(3);
         try {
-          Config.load(['--invalid', './script.bas'], {});
+          new Config(['--invalid', './script.bas'], {});
         } catch (err) {
           t.type(err, UsageFault);
           t.match(err.message, /^Invalid option: --invalid/);
@@ -154,14 +154,14 @@ t.test('level', async (t: Test) => {
   t.test('when no level is passed', async (t: Test) => {
     t.test('and there is no environment variable', async (t: Test) => {
       t.test('the level is set to info', async (t: Test) => {
-        const config = Config.load([], {});
+        const config = new Config([], {});
         t.equal(config.level, Level.Info);
       });
     });
 
     t.test('but there is a valid environment variable', async (t: Test) => {
       t.test('the level is set to that level', async (t: Test) => {
-        const config = Config.load([], { MATBAS_LOG_LEVEL: 'debug' });
+        const config = new Config([], { MATBAS_LOG_LEVEL: 'debug' });
         t.equal(config.level, Level.Debug);
       });
     });
@@ -170,7 +170,7 @@ t.test('level', async (t: Test) => {
       t.test('it exits with a usage fault', async (t: Test) => {
         t.plan(3);
         try {
-          Config.load([], { MATBAS_LOG_LEVEL: 'fatal' });
+          new Config([], { MATBAS_LOG_LEVEL: 'fatal' });
         } catch (err) {
           t.type(err, UsageFault);
           t.match(err.message, /^Invalid log level: fatal/);
@@ -182,7 +182,7 @@ t.test('level', async (t: Test) => {
 
   t.test('when a valid level is passed', async (t: Test) => {
     t.test('the level is set to that level', async (t: Test) => {
-      const config = Config.load(['--log-level', 'debug'], {});
+      const config = new Config(['--log-level', 'debug'], {});
       t.equal(config.level, Level.Debug);
     });
   });
@@ -191,7 +191,7 @@ t.test('level', async (t: Test) => {
     t.test('it exits with a usage fault', async (t: Test) => {
       t.plan(3);
       try {
-        Config.load(['--log-level', 'fatal'], {});
+        new Config(['--log-level', 'fatal'], {});
       } catch (err) {
         t.type(err, UsageFault);
         t.match(err.message, /^Invalid log level: fatal/);

--- a/test/helpers/cli.ts
+++ b/test/helpers/cli.ts
@@ -36,10 +36,6 @@ export async function run(
           useValue: env,
         },
         {
-          provide: Config,
-          useValue: Config.load(argv, env),
-        },
-        {
           provide: 'exitFn',
           useValue: (exitCode: number): void => {
             resolve({
@@ -48,6 +44,7 @@ export async function run(
             });
           },
         },
+        Config,
         Editor,
         Executor,
         App,

--- a/test/helpers/config.ts
+++ b/test/helpers/config.ts
@@ -1,4 +1,0 @@
-import { Config } from '../../config';
-import { Level } from '../../host';
-
-export const CONFIG = new Config(null, null, null, Level.Info, ['matbas'], {});

--- a/test/helpers/executor.ts
+++ b/test/helpers/executor.ts
@@ -4,7 +4,6 @@ import { discuss } from '@jfhbrook/swears';
 import { Config } from '../../config';
 import { Editor } from '../../editor';
 import { Executor } from '../../executor';
-import { CONFIG } from './config';
 import { MockConsoleHost } from './host';
 
 class MockExecutor extends Executor {}
@@ -20,7 +19,7 @@ export const executorTopic = discuss(
         },
         {
           provide: Config,
-          useValue: CONFIG,
+          useValue: new Config([], {}),
         },
         Editor,
         {


### PR DESCRIPTION
The config object uses a dataclasses-like pattern, with a static method that generates a Config using argv and env. I like this pattern because it makes it easy to make a config without leveraging arguments parsing. However, it makes dependency injection a little more awkward.

This is what going the other direction looks like.